### PR TITLE
Better json format

### DIFF
--- a/modules/atomic_update.py
+++ b/modules/atomic_update.py
@@ -2,6 +2,7 @@ import orjson
 from atomicwrites import atomic_write
 from logging_config import get_logger
 from json import JSONDecodeError
+import json
 
 logger = get_logger(__name__)
 
@@ -9,7 +10,7 @@ def atomic_write_json(data, file_path, temp_dir='tmp/'):
     try:
         logger.info(f"Attempting to write JSON data to file: {file_path}")
         with atomic_write(file_path, overwrite=True, mode='wb', dir=temp_dir) as f:
-            f.write(orjson.dumps(data))
+            f.write(json.dumps(data, indent=4).encode('utf-8'))
         logger.info(f"Successfully wrote JSON data to file: {file_path}")
     except Exception as e:
         logger.exception(f"Error writing JSON data to file {file_path}: {e}")
@@ -37,7 +38,7 @@ def atomic_append_json(new_data, file_path, temp_dir='tmp/'):
     merged_data = {**existing_data, **new_data}
     try:
         with atomic_write(file_path, overwrite=True, mode='wb', dir=temp_dir) as f:
-            f.write(orjson.dumps(merged_data))
+            f.write(json.dumps(merged_data, indent=4).encode('utf-8'))
         logger.info(f"Successfully appended JSON data to file: {file_path}")
     except Exception as e:
         logger.exception(f"Error appending JSON data to file {file_path}: {e}")
@@ -71,7 +72,7 @@ def atomic_append_dict(new_data, file_path, temp_dir='tmp/'):
     try:
         # Write the merged data back to the file atomically
         with atomic_write(file_path, overwrite=True, mode='wb', dir=temp_dir) as f:
-            f.write(orjson.dumps(existing_data))
+            f.write(json.dumps(existing_data, indent=4).encode('utf-8'))
         logger.info(f"Successfully updated JSON data in file: {file_path}")
     except Exception as e:
         logger.exception(f"Error updating JSON data in file {file_path}: {e}")

--- a/modules/conflict_resolver.py
+++ b/modules/conflict_resolver.py
@@ -1,5 +1,6 @@
 import orjson
 from config import Config
+import json
 
 class ConflictResolver:
     def __init__(self, config):
@@ -32,13 +33,13 @@ class ConflictResolver:
 
     def save_machine_solutions(self):
             """Save machine solutions to a JSON file."""
-            with open(self.config.get('data', 'machine_solution_path'), 'wb') as f:
-                f.write(orjson.dumps(self.machine_solutions))
+            with open(self.config.get('data', 'machine_solution_path'), 'w') as f:
+                f.write(json.dumps(self.machine_solutions, indent=4))
 
     def save_user_solutions(self):
         """Save user solutions to a JSON file."""
-        with open(self.config.get('data', 'user_solution_path'), 'wb') as f:
-            f.write(orjson.dumps(self.user_solutions))
+        with open(self.config.get('data', 'user_solution_path'), 'w') as f:
+            f.write(json.dumps(self.user_solutions, indent=4))
 
     def detect_and_resolve_conflicts(self):
         """Detect and resolve conflicts between machine and user solutions."""


### PR DESCRIPTION
Fixes #81

Update JSON serialization to improve legibility by saving dictionaries with one entry per line.

* **modules/atomic_update.py**
  - Update `atomic_write_json` to use `json.dumps(data, indent=4)` instead of `orjson.dumps(data)`.
  - Update `atomic_append_json` to use `json.dumps(merged_data, indent=4)` instead of `orjson.dumps(merged_data)`.
  - Update `atomic_append_dict` to use `json.dumps(existing_data, indent=4)` instead of `orjson.dumps(existing_data)`.

* **modules/conflict_resolver.py**
  - Update `save_machine_solutions` to use `json.dumps(self.machine_solutions, indent=4)` instead of `orjson.dumps(self.machine_solutions)`.
  - Update `save_user_solutions` to use `json.dumps(self.user_solutions, indent=4)` instead of `orjson.dumps(self.user_solutions)`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Pantagrueliste/Amanuensis/pull/82?shareId=22eff9e7-4955-416b-964d-769852a34994).